### PR TITLE
Observers are not actually removed when many

### DIFF
--- a/src/pmvcpp.cpp
+++ b/src/pmvcpp.cpp
@@ -304,6 +304,8 @@ void View::removeObserver( int notificationName, intptr_t contextAddress )
                 break;
             }
         }
+        
+        this->observerMap[notificationName] = observers;
 
         if(observers.size() == (size_t) 0)
            this->observerMap.erase(notificationName);


### PR DESCRIPTION
Observers are not actually removed if there are more than one observer for the same notificationName
